### PR TITLE
Switch to Apache license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+Copyright (c) 2025 The MIDI ML Project Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# MIDI ML Project
+
+This repository contains code and datasets used for experimenting with machine learning techniques on MIDI files. Scripts cover tasks such as extracting chords, preprocessing moods, training mood classifiers and analyzing results.
+
+## License
+
+This project is open source under the [MIT License](LICENSE). See the LICENSE file for details.


### PR DESCRIPTION
## Summary
- use the Apache 2.0 license instead of MIT

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873e3e68a708333a643bc962781c6ff